### PR TITLE
Add missing properties to SfxTrigger

### DIFF
--- a/GeometryDashAPI/Levels/GameObjects/Triggers/SfxTrigger.cs
+++ b/GeometryDashAPI/Levels/GameObjects/Triggers/SfxTrigger.cs
@@ -41,6 +41,21 @@ public class SfxTrigger : Trigger
 
     [GameProperty("406", 1f, alwaysSet: true)]
     public float Volume { get; set; } = 1f;
+    
+    [GameProperty("455", 0)]
+    public int SfxGroup { get; set; }
+    
+    [GameProperty("408", 0)]
+    public int Start { get; set; }
+    
+    [GameProperty("410", 0)]
+    public int End { get; set; }
+    
+    [GameProperty("409", 0)]
+    public int FadeIn { get; set; }
+    
+    [GameProperty("411", 0)]
+    public int FadeOut { get; set; }
 
     [GameProperty("407", false)]
     public bool Reverb { get; set; }


### PR DESCRIPTION
This pull request adds the following properties to the SfxTrigger class:
- SFX group, ID 455.
- Start, ID 408.
- End, ID 410.
- Fade in, ID 409.
- Fade out, ID 411.